### PR TITLE
updated reference links to User Manual

### DIFF
--- a/guides/NamingGuide.md
+++ b/guides/NamingGuide.md
@@ -82,4 +82,4 @@
   - [Variable Names](https://docs.julialang.org/en/v1/manual/variables/#Stylistic-Conventions-1)
   - [Style Guide](https://docs.julialang.org/en/v1/manual/style-guide/)
   - [Function Names](https://docs.julialang.org/en/v1/manual/style-guide/#Use-naming-conventions-consistent-with-Julia-base/-1)
-  - [Package Names](https://docs.julialang.org/en/v0.6/manual/packages/#Guidelines-for-naming-a-package-1)
+  - [Package Names](https://julialang.github.io/Pkg.jl/stable/creating-packages/#Package-naming-guidelines-1)

--- a/guides/NamingGuide.md
+++ b/guides/NamingGuide.md
@@ -79,6 +79,7 @@
 ## For Reference
 
 - The User Manual
-
-  - [Package Names](http://docs.julialang.org/en/latest/manual/packages/#guidelines-for-naming-a-package)
-  - [Function Names](http://docs.julialang.org/en/latest/manual/style-guide/#use-naming-conventions-consistent-with-julia-s-base)
+  - [Variable Names](https://docs.julialang.org/en/v1/manual/variables/#Stylistic-Conventions-1)
+  - [Style Guide](https://docs.julialang.org/en/v1/manual/style-guide/)
+  - [Function Names](https://docs.julialang.org/en/v1/manual/style-guide/#Use-naming-conventions-consistent-with-Julia-base/-1)
+  - [Package Names](https://docs.julialang.org/en/v0.6/manual/packages/#Guidelines-for-naming-a-package-1)


### PR DESCRIPTION
It looks like the package naming guidance has disappeared from v1